### PR TITLE
fix: Hide header value if not valid

### DIFF
--- a/okhttp/src/main/java/okhttp3/Headers.java
+++ b/okhttp/src/main/java/okhttp3/Headers.java
@@ -270,7 +270,7 @@ public final class Headers {
       char c = value.charAt(i);
       if ((c <= '\u001f' && c != '\t') || c >= '\u007f') {
         throw new IllegalArgumentException(Util.format(
-            "Unexpected char %#04x at %d in %s value: %s", (int) c, i, name, value));
+            "Unexpected char %#04x at %d in %s value", (int) c, i, name));
       }
     }
   }
@@ -299,7 +299,7 @@ public final class Headers {
     public Builder add(String line) {
       int index = line.indexOf(":");
       if (index == -1) {
-        throw new IllegalArgumentException("Unexpected header: " + line);
+        throw new IllegalArgumentException("Unexpected header");
       }
       return add(line.substring(0, index).trim(), line.substring(index + 1));
     }


### PR DESCRIPTION
Reference: https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044
Official fix: https://github.com/square/okhttp/pull/6551/files
Original migitation: https://github.com/DataDog/dd-trace-java/pull/3682/files