### PR TITLE
Configure sign key CI

### DIFF
--- a/.buildscript/settings.xml
+++ b/.buildscript/settings.xml
@@ -7,5 +7,9 @@
             <username>${env.SONATYPE_USER}</username>
             <password>${env.SONATYPE_PASS}</password>
         </server>
+        <server>
+            <id>gpg.passphrase</id>
+            <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+        </server>
     </servers>
 </settings>

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,15 +29,15 @@ deploy_to_sonatype:
     - apt install -y maven
 
     - echo "Fetching Sonatype user..."
-    - export SONATYPE_USER=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.publishing.sonatype_username --with-decryption --query "Parameter.Value" --out text)
+    - export SONATYPE_USER=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_username --with-decryption --query "Parameter.Value" --out text)
     - echo "Fetching Sonatype password..."
-    - export SONATYPE_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.publishing.sonatype_password --with-decryption --query "Parameter.Value" --out text)
+    - export SONATYPE_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_password --with-decryption --query "Parameter.Value" --out text)
 
     - echo "Fetching signing key password..."
-    - export GPG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
+    - export GPG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
 
     - echo "Fetching signing key..."
-    - gpg_key=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
+    - gpg_key=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - printf -- "$gpg_key" | gpg --import --batch
 
     - set -x
@@ -67,7 +67,7 @@ create_key:
   image: $REGISTRY/ci/agent-key-management-tools/gpg:1
 
   variables:
-    PROJECT_NAME: "dd-trace-java"
+    PROJECT_NAME: "okhttp"
 
   script:
     - /create.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,13 +49,13 @@ deploy_to_sonatype:
   artifacts:
     expire_in: 12 mos
     paths:
-      - ./target/*.jar
-      - ./target/*.pom
-      - ./target/*.asc
-      - ./target/*.md5
-      - ./target/*.sha1
-      - ./target/*.sha256
-      - ./target/*.sha512
+      - okhttp/target/*.jar
+      - okhttp/target/*.pom
+      - okhttp/target/*.asc
+      - okhttp/target/*.md5
+      - okhttp/target/*.sha1
+      - okhttp/target/*.sha256
+      - okhttp/target/*.sha512
 
 # This job creates the GPG key used to sign the releases
 create_key:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,19 +60,16 @@ deploy_to_sonatype:
 create_key:
   stage: create_key
   when: manual
-
-  tags:
-    - "runner:docker"
-
-  image: $REGISTRY/ci/agent-key-management-tools/gpg:1
-
+  needs: []
+  tags: [ "runner:docker", "size:large" ]
   variables:
     PROJECT_NAME: "okhttp"
-
+    EXPORT_TO_KEYSERVER: "false"
+  image: $REGISTRY/ci/agent-key-management-tools/gpg:1
   script:
+    - mkdir pubkeys
     - /create.sh
-
   artifacts:
     expire_in: 13 mos
     paths:
-      - ./pubkeys/
+      - pubkeys

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,16 +17,17 @@ deploy_to_sonatype:
   tags:
     - "runner:docker"
 
-  image: datadog/dd-trace-java-docker-build:latest
+  image: maven:3.6.3-jdk-8-slim
 
   script:
     # Ensure we don't print commands being run to the logs during credential
     # operations
     - set +x
 
-    - echo "Installing Maven..."
+    - echo "Installing AWSCLI..."
     - apt update
-    - apt install -y maven
+    - apt install -y python3 python3-pip
+    - python3 -m pip install awscli
 
     - echo "Fetching Sonatype user..."
     - export SONATYPE_USER=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_username --with-decryption --query "Parameter.Value" --out text)
@@ -43,7 +44,7 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -pl :okhttp -DperformRelease=true --settings ./.buildscript/settings.xml clean deploy
+    - mvn -pl :okhttp -DperformRelease=true --settings ./.buildscript/settings.xml -P !alpn-when-jdk8 clean deploy
 
   artifacts:
     expire_in: 12 mos

--- a/pom.xml
+++ b/pom.xml
@@ -728,6 +728,32 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <name>OkHttp (Parent)</name>
   <description>An HTTP+HTTP/2 client for Android and Java applications</description>
-  <url>https://github.com/square/okhttp</url>
+  <url>https://github.com/DataDog/okhttp</url>
 
   <modules>
     <module>okhttp</module>
@@ -67,15 +67,15 @@
   </properties>
 
   <scm>
-    <url>https://github.com/square/okhttp/</url>
-    <connection>scm:git:https://github.com/square/okhttp.git</connection>
-    <developerConnection>scm:git:git@github.com:square/okhttp.git</developerConnection>
+    <url>https://github.com/DataDog/okhttp/tree/java7</url>
+    <connection>scm:git:https://github.com/DataDog/okhttp.git</connection>
+    <developerConnection>scm:git:ssh://github.com:DataDog/okhttp.git</developerConnection>
     <tag>parent-3.12.0</tag>
   </scm>
 
   <issueManagement>
     <system>GitHub Issues</system>
-    <url>https://github.com/square/okhttp/issues</url>
+    <url>https://github.com/DataDog/okhttp/issues</url>
   </issueManagement>
 
   <licenses>


### PR DESCRIPTION
As permissions was updated, we should be able to use our own `okhttp` namespace to create and store sign key.
Also fix public key upload to gitlab CI result as `pubkeys` folder is missing (I don't know if it is on purpose but it fails to upload keys on `dd-trace-java` and `jmxfetch` too)