### PR TITLE
Prepare for Central Portal deployment

### DIFF
--- a/.buildscript/settings.xml
+++ b/.buildscript/settings.xml
@@ -3,9 +3,9 @@
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <servers>
         <server>
-            <id>nexus</id>
-            <username>${env.SONATYPE_USER}</username>
-            <password>${env.SONATYPE_PASS}</password>
+            <id>central</id>
+            <username>${env.CENTRAL_USERNAME}</username>
+            <password>${env.CENTRAL_PASSWORD}</password>
         </server>
         <server>
             <id>gpg.passphrase</id>

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ deploy_to_sonatype:
   tags:
     - "runner:docker"
 
-  image: maven:3.6.3-jdk-8-slim
+  image: maven:3.9-eclipse-temurin-8
 
   script:
     # Ensure we don't print commands being run to the logs during credential

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,10 +29,20 @@ deploy_to_sonatype:
     - apt install -y python3 python3-pip
     - python3 -m pip install awscli
 
-    - echo "Fetching Sonatype user..."
-    - export SONATYPE_USER=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_username --with-decryption --query "Parameter.Value" --out text)
-    - echo "Fetching Sonatype password..."
-    - export SONATYPE_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_password --with-decryption --query "Parameter.Value" --out text)
+    # TODO:
+    # Replace SSM parameters
+    #   ci.okhttp.publishing.sonatype_username -> ci.okhttp.central_username
+    #   ci.okhttp.publishing.sonatype_password -> ci.okhttp.central_password
+    #
+    # Get a new token from central, old tokens are not compatible.
+    #
+    # Set the new entries (and replace old entries):
+    #     ci-secrets set ci.okhttp.central_username
+    #     ci-secrets set ci.okhttp.central_password
+    - echo "Fetching Central Portal username..."
+    - export CENTRAL_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_username --with-decryption --query "Parameter.Value" --out text)
+    - echo "Fetching Central Portal password..."
+    - export CENTRAL_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.publishing.sonatype_password --with-decryption --query "Parameter.Value" --out text)
 
     - echo "Fetching signing key password..."
     - export GPG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.okhttp.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -108,6 +108,9 @@
                 <goal>flatten</goal>
               </goals>
               <configuration>
+                <!-- "ossrh" is a historical mode name; it still produces the correct
+                     flattened POM format expected by Maven Central Portal (central.sonatype.com).
+                     No change needed despite the OSSRH → Central Portal migration. -->
                 <flattenMode>ossrh</flattenMode>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <groupId>com.datadoghq.okhttp3</groupId>
   <artifactId>parent</artifactId>
   <version>3.12.15</version>
@@ -721,21 +715,6 @@
         </property>
       </activation>
 
-      <distributionManagement>
-        <snapshotRepository>
-          <id>nexus</id>
-          <!-- Use the localhost endpoint for testing -->
-          <!-- <url>http://localhost:8081/repository/maven-snapshots/</url> -->
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-          <id>nexus</id>
-          <!-- Use the localhost endpoint for testing -->
-          <!-- <url>http://localhost:8081/repository/maven-releases/</url> -->
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-      </distributionManagement>
-
       <build>
         <plugins>
           <plugin>
@@ -765,16 +744,15 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.6</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.9.0</version>
+            <!-- enble the plugin to run during deploy phase -->
             <extensions>true</extensions>
             <configuration>
-              <serverId>nexus</serverId>
-              <!-- Use the localhost endpoint for testing -->
-              <!-- <nexusUrl>http://localhost:8081/repository/maven-releases/</nexusUrl> -->
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <!-- Manual publish for now -->
+              <autoPublish>false</autoPublish>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
## Migrate publishing from OSSRH to Maven Central Portal

OSSRH (`oss.sonatype.org`) was shut down on June 30, 2025. This PR migrates the
release pipeline to the new [Maven Central Portal](https://central.sonatype.com) using the `central-publishing-maven-plugin`.

### Changes

- Removed `oss-parent` (contributed `distributionManagement` pointing to the dead OSSRH URLs and a `release-sign-artifacts` profile already overridden locally)
- Removed `<distributionManagement>` block
- Replaced `nexus-staging-maven-plugin` by `central-publishing-maven-plugin`
- Update the maven image to 3.9
- SSM parameter names are kept unchanged for now; but they need to be updated.


### Remaining tasks

- [ ] Re-enable the CI ?
- [ ] Possibly generate a Central Portal user token on https://central.sonatype.com 
 Note that last year it wasn't possible to have multiple token, so **do not regenerate existing** if it's not possible to create another one — otherwise it will invalidate the previous tokens.
- [ ] Store the token in AWS SSM
