### PR TITLE
Patch OkHttp's Util class to always create daemon threads

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -245,7 +245,7 @@ public final class Util {
     return new ThreadFactory() {
       @Override public Thread newThread(Runnable runnable) {
         Thread result = new Thread(runnable, name);
-        result.setDaemon(daemon);
+        result.setDaemon(true); // always create daemon threads
         return result;
       }
     };


### PR DESCRIPTION
This avoids a potential shutdown delay when using HTTP/2 connections.