### PR TITLE
fix: backport CVE-2021-0341 hostname verification bypass to Java

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
@@ -1610,6 +1610,14 @@ public final class HttpUrlTest {
     assertNull(parse("https://127.0.0.1").topPrivateDomain());
   }
 
+  @Test public void hostnameTelephone() {
+    // https://www.gosecure.net/blog/2020/10/27/weakness-in-java-tls-host-verification/
+    // Map the single character telephone symbol (℡) to the string "tel".
+    assertEquals("tel", parse("http://℡").host());
+    // Map the Kelvin symbol (K) to the string "k".
+    assertEquals("k", parse("http://K").host());
+  }
+
   private void assertInvalid(String string, String exceptionMessage) {
     if (useGet) {
       try {

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
@@ -542,6 +542,30 @@ public final class HostnameVerifierTest {
     assertFalse(Util.verifyAsIpAddress("www.nintendo.co.jp"));
   }
 
+  /** https://github.com/square/okhttp/security/advisories/GHSA-g2ro-prf6-rf7g (CVE-2021-0341) */
+  @Test public void verifyHostnameRejectsNonAsciiInPattern() {
+    // U+212A (Kelvin sign) lowercases to 'k' via Locale.US — must not match ASCII 'k.com'
+    assertFalse(OkHostnameVerifier.INSTANCE.verifyHostname("k.com", "K.com"));
+  }
+
+  /** https://github.com/square/okhttp/security/advisories/GHSA-g2ro-prf6-rf7g (CVE-2021-0341) */
+  @Test public void verifyRejectsNonAsciiHostname() throws Exception {
+    // Cert with SAN k.com: without the fix, Kelvin (U+212A) toLowerCase -> 'k' would match
+    SSLSession session = session(""
+        + "-----BEGIN CERTIFICATE-----\n"
+        + "MIIBWTCCAQOgAwIBAgIUCIjtciFGQ7th8gIrYJSJ9LvhSJ4wDQYJKoZIhvcNAQEL\n"
+        + "BQAwEDEOMAwGA1UEAwwFay5jb20wIBcNMjYwNjIyMTQxNDQxWhgPMjEyNjA1Mjkx\n"
+        + "NDE0NDFaMBAxDjAMBgNVBAMMBWsuY29tMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJB\n"
+        + "AK39vBFqL9h7yvHaJE2REXsKTvQbcSMBDDx/145+gbemVt9YpSmywODUGHPKmiLa\n"
+        + "5ZT5g+1fz5Ps4KJ0xyE2G40CAwEAAaMzMDEwEAYDVR0RBAkwB4IFay5jb20wHQYD\n"
+        + "VR0OBBYEFBrWz5ZhWsRW3jSrRnixtwXJIALgMA0GCSqGSIb3DQEBCwUAA0EAX9II\n"
+        + "yp4Pyg7lTwxULabW1EhnSPrc4yl/kQi+HBiW55t1dhi0NV6OY6XS4ctxQJBVwkiJ\n"
+        + "Wbt98UgA+Up7ywDEaw==\n"
+        + "-----END CERTIFICATE-----\n");
+    assertTrue(verifier.verify("k.com", session));
+    assertFalse(verifier.verify("K.com", session)); // U+212A Kelvin: toLowerCase would give 'k'
+  }
+
   private X509Certificate certificate(String certificate) throws Exception {
     return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(
         new ByteArrayInputStream(certificate.getBytes(Util.UTF_8)));

--- a/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
@@ -28,6 +28,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 
+import static okhttp3.internal.Util.indexOfControlOrNonAscii;
 import static okhttp3.internal.Util.verifyAsIpAddress;
 
 /**
@@ -44,6 +45,9 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
   @Override
   public boolean verify(String host, SSLSession session) {
+    if (!isAscii(host)) {
+      return false;
+    }
     try {
       Certificate[] certificates = session.getPeerCertificates();
       return verify(host, (X509Certificate) certificates[0]);
@@ -71,7 +75,7 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
   /** Returns true if {@code certificate} matches {@code hostname}. */
   private boolean verifyHostname(String hostname, X509Certificate certificate) {
-    hostname = hostname.toLowerCase(Locale.US);
+    hostname = asciiToLowercase(hostname);
     List<String> altNames = getSubjectAltNames(certificate, ALT_DNS_NAME);
     for (String altName : altNames) {
       if (verifyHostname(hostname, altName)) {
@@ -157,7 +161,7 @@ public final class OkHostnameVerifier implements HostnameVerifier {
     }
     // hostname and pattern are now absolute domain names.
 
-    pattern = pattern.toLowerCase(Locale.US);
+    pattern = asciiToLowercase(pattern);
     // hostname and pattern are now in lower case -- domain names are case-insensitive.
 
     if (!pattern.contains("*")) {
@@ -212,5 +216,27 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
     // hostname matches pattern
     return true;
+  }
+
+  /**
+   * Returns true if {@code s} contains only ASCII characters.
+   *
+   * <p>The upstream Kotlin fix uses {@code s.length == s.utf8Size()} (Okio), which accepts all
+   * code points 0x00–0x7F including control characters. {@link Util#indexOfControlOrNonAscii}
+   * is slightly stricter: it also rejects control characters (0x00–0x1F) and DEL (0x7F). For
+   * hostnames this is fine as control characters are never valid in a hostname per RFC 952/1123,
+   * so the extra rejection is correct, not a regression.
+   */
+  private static boolean isAscii(String s) {
+    return indexOfControlOrNonAscii(s) == -1;
+  }
+
+  /**
+   * This is like {@link String#toLowerCase} except that it does nothing if {@code s} contains any
+   * non-ASCII characters. We want to avoid lower casing special chars like U+212A (Kelvin symbol)
+   * because they can return ASCII characters that match real hostnames.
+   */
+  private static String asciiToLowercase(String s) {
+    return isAscii(s) ? s.toLowerCase(Locale.US) : s;
   }
 }


### PR DESCRIPTION
Unicode characters whose case-folding produces ASCII can spoof hostname verification. `U+212A` (Kelvin sign) lowercases to 'k' via `Locale.US`, so a certificate with `SAN` `K.com` would match host `k.com` under the old code.

Note however that this is only possible if using this internal class directly, which is abnormal, OkHttp, uses `HttpUrl` especially to handle anything, and this class properly check the authorized characters.

See https://github.com/DataDog/dd-trace-java/issues/11631#issuecomment-4768739824

Cherry-pick of square/okhttp#6741 (OkHttp 4.9.2) from Kotlin to Java:

- Reject non-ASCII hostnames early in `verify(String, SSLSession)` via `isAscii()`, mirroring the Kotlin fix's `!host.isAscii()`.
- Note that `isAscii()` delegates to the existing `Util.indexOfControlOrNonAscii()`, which is slightly stricter than the Kotlin's `utf8Size()` check: it also rejects control characters (`0x00`–`0x1F`) and `DEL` (`0x7F`), both invalid in hostnames per RFC 952/1123.